### PR TITLE
Reset form to Info tab when opening new session

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -151,6 +151,13 @@ async function newSession() {
   clearReviewForm();
 
   document.getElementById('session-form-title').textContent = 'New Session';
+
+  // Always open to the Info tab
+  document.querySelectorAll('.form-tab').forEach(t => t.classList.remove('active'));
+  document.querySelector('.form-tab[data-tab="tab-header"]').classList.add('active');
+  document.querySelectorAll('.form-tab-content').forEach(c => c.classList.remove('active'));
+  document.getElementById('tab-header').classList.add('active');
+
   document.getElementById('session-form').hidden = false;
 
   // Create session immediately so sub-items can attach


### PR DESCRIPTION
Closes #12

## Summary
- `newSession()` wasn't resetting the active form tab when reopening the modal
- If the user previously navigated to Packs/Tricks/etc. and then closed the form, the next "+ Log Session" click would reopen to that same tab — showing an empty list with no visible fields, making it look like the form hadn't loaded
- Fix: explicitly activate the Info tab and its content before showing the modal

## Test plan
- [ ] Open "+ Log Session", navigate to Packs tab, close the form
- [ ] Click "+ Log Session" again from Today tab — should open to Info tab with date/location/etc. filled in
- [ ] Same check from Sessions tab "+ New" button

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4SScoqQnH3HaehhJxLDqB)_