### PR TITLE
Rename app from "FPV Training Tracker" to "flowchart"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,8 +55,8 @@ jobs:
 
       - name: Test Docker image
         run: |
-          docker build -t fpv-tracker-test .
-          docker run -d --name fpv-test -p 3000:3000 fpv-tracker-test
+          docker build -t flowchart-test .
+          docker run -d --name flowchart-test -p 3000:3000 flowchart-test
 
           # Wait for container to be ready
           for i in $(seq 1 30); do
@@ -74,7 +74,7 @@ jobs:
           [ "$TRICKS" -gt 0 ] || { echo "FAIL: container not serving data"; exit 1; }
 
           echo "Docker image test passed!"
-          docker stop fpv-test
+          docker stop flowchart-test
 
   update-rtappstore:
     needs: build-and-push
@@ -95,7 +95,7 @@ jobs:
           NEW_IMAGE="ghcr.io/cori/flowchart:sha-${SHORT_SHA}"
 
           # Update config.json: increment tipi_version only when version SHA changes
-          CONFIG_INFO=$(gh api repos/cori/rtappstore/contents/apps/fpv-tracker/config.json)
+          CONFIG_INFO=$(gh api repos/cori/rtappstore/contents/apps/flowchart/config.json)
           CONFIG_SHA=$(echo "$CONFIG_INFO" | python3 -c "import sys,json; print(json.load(sys.stdin)['sha'])")
           CURRENT_VERSION=$(echo "$CONFIG_INFO" | python3 -c "import sys,json,base64; print(json.loads(base64.b64decode(json.load(sys.stdin)['content']).decode()).get('version',''))")
           if [ "$CURRENT_VERSION" = "sha-${SHORT_SHA}" ]; then
@@ -103,15 +103,15 @@ jobs:
           else
             NEW_CONFIG=$(echo "$CONFIG_INFO" | python3 -c "import sys,json,base64; info=json.load(sys.stdin); data=json.loads(base64.b64decode(info['content']).decode()); data['tipi_version']+=1; data['version']='sha-$SHORT_SHA'; print(json.dumps(data,indent=2))")
             NEW_CONFIG_B64=$(printf '%s' "$NEW_CONFIG" | base64 -w 0)
-            gh api repos/cori/rtappstore/contents/apps/fpv-tracker/config.json \
+            gh api repos/cori/rtappstore/contents/apps/flowchart/config.json \
               -X PUT \
-              -f message="chore: update fpv-tracker to sha-${SHORT_SHA}" \
+              -f message="chore: update flowchart to sha-${SHORT_SHA}" \
               -f content="${NEW_CONFIG_B64}" \
               -f sha="${CONFIG_SHA}"
           fi
 
           # Update docker-compose.json: pin to new image tag (skip if unchanged)
-          DC_INFO=$(gh api repos/cori/rtappstore/contents/apps/fpv-tracker/docker-compose.json)
+          DC_INFO=$(gh api repos/cori/rtappstore/contents/apps/flowchart/docker-compose.json)
           DC_SHA=$(echo "$DC_INFO" | python3 -c "import sys,json; print(json.load(sys.stdin)['sha'])")
           DC_CONTENT=$(echo "$DC_INFO" | python3 -c "import sys,json,base64; print(base64.b64decode(json.load(sys.stdin)['content']).decode())")
           NEW_DC=$(printf '%s' "$DC_CONTENT" | sed "s|ghcr.io/cori/flowchart:sha-[a-z0-9]*|${NEW_IMAGE}|g")
@@ -119,9 +119,9 @@ jobs:
             echo "rtappstore docker-compose already up-to-date, skipping"
           else
             NEW_DC_B64=$(printf '%s' "$NEW_DC" | base64 -w 0)
-            gh api repos/cori/rtappstore/contents/apps/fpv-tracker/docker-compose.json \
+            gh api repos/cori/rtappstore/contents/apps/flowchart/docker-compose.json \
               -X PUT \
-              -f message="chore: update fpv-tracker image to sha-${SHORT_SHA}" \
+              -f message="chore: update flowchart image to sha-${SHORT_SHA}" \
               -f content="${NEW_DC_B64}" \
               -f sha="${DC_SHA}"
           fi

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FPV Training Tracker
+# flowchart
 
 A self-hostable PWA for tracking FPV freestyle training progress, session logs, trick mastery, and the 20-week "Plan to Denver."
 
@@ -61,8 +61,8 @@ npm run dev
 ## Docker
 
 ```bash
-docker build -t fpv-tracker .
-docker run -p 3000:3000 -v ./data:/app/data fpv-tracker
+docker build -t flowchart .
+docker run -p 3000:3000 -v ./data:/app/data flowchart
 ```
 
 Or with docker-compose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: "3.7"
 services:
-  fpv-tracker:
+  flowchart:
     build: .
-    container_name: fpv-tracker
+    container_name: flowchart
     restart: unless-stopped
     ports:
       - "${APP_PORT:-3000}:3000"
@@ -10,4 +10,4 @@ services:
       - ${APP_DATA_DIR:-./data}:/app/data
     environment:
       - NODE_ENV=production
-      - DB_PATH=/app/data/fpv-tracker.db
+      - DB_PATH=/app/data/flowchart.db

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fpv-tracker",
+  "name": "flowchart",
   "version": "1.0.0",
   "description": "FPV freestyle training tracker - session logs, trick mastery, phase progression",
   "type": "module",

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
   <meta name="theme-color" content="#1a1a2e">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>FPV Training Tracker</title>
+  <title>flowchart</title>
   <link rel="manifest" href="/manifest.json">
   <link rel="icon" href="/icons/icon-192.svg">
   <link rel="apple-touch-icon" href="/icons/icon-192.svg">
@@ -17,7 +17,7 @@
     <!-- TODAY TAB -->
     <section id="page-today" class="page active">
       <header class="page-header">
-        <h1>FPV Tracker</h1>
+        <h1>flowchart</h1>
         <div style="display:flex;align-items:center;gap:6px">
           <span id="today-week" class="badge">Week 1</span>
           <span id="app-version" style="font-size:0.7rem;color:var(--fg2)"></span>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "FPV Training Tracker",
-  "short_name": "FPV Tracker",
+  "name": "flowchart",
+  "short_name": "flowchart",
   "description": "Track FPV freestyle training - sessions, tricks, progress to Denver",
   "start_url": "/",
   "display": "standalone",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'fpv-tracker-v1';
+const CACHE_NAME = 'flowchart-v1';
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,5 +30,5 @@ app.get('/api/health', (c) => c.json({ status: 'ok', version: APP_VERSION }));
 app.use('/*', serveStatic({ root: './public' }));
 
 const port = parseInt(process.env.PORT || '3000', 10);
-console.log(`FPV Tracker listening on http://localhost:${port}`);
+console.log(`flowchart listening on http://localhost:${port}`);
 serve({ fetch: app.fetch, port });


### PR DESCRIPTION
## Summary

- Renames `package.json` name, `<title>`, `<h1>`, PWA manifest, and service worker cache key from "FPV Training Tracker" / "fpv-tracker" to "flowchart"
- Updates `docker-compose.yml` service/container names and `DB_PATH` to use `flowchart.db`
- Updates README Docker examples and CI workflow container/stop names
- Migrates rtappstore from `apps/fpv-tracker/` to `apps/flowchart/` with updated `id`, `name`, `description`, and `DB_PATH`; bumps `tipi_version` to 6 to trigger fresh install on Runtipi

## Test plan

- [ ] `npm start` logs `flowchart listening on http://localhost:3000`
- [ ] Browser title shows "flowchart", h1 shows "flowchart"
- [ ] `manifest.json` name/short_name are "flowchart"
- [ ] `docker-compose up` starts container named `flowchart`
- [ ] CI Docker test step builds/stops `flowchart-test` container
- [ ] rtappstore `apps/flowchart/` files present; `apps/fpv-tracker/` deleted

Resolves #23

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4SScoqQnH3HaehhJxLDqB)_