### PR TITLE
Implement training plans

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ curl -sf http://localhost:3000/api/tricks | jq length
 ### Environment
 
 - `PORT` - Server port (default: 3000)
-- `DB_PATH` - SQLite database path (default: `data/fpv-tracker.db`)
+- `DB_PATH` - SQLite database path (default: `data/flowchart.db`)
 
 ## Tech Stack
 
@@ -206,7 +206,7 @@ public/
 
 - The app is offline-first (PWA with service worker)
 - No authentication/authorization (self-hosted, single user)
-- Data is stored in SQLite file at `data/fpv-tracker.db`
+- Data is stored in SQLite file at `data/flowchart.db`
 - Frontend has no build step - edit HTML/CSS/JS and refresh
 
 ## Testing Workflows

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ RUN mkdir -p /app/data
 EXPOSE 3000
 
 ENV NODE_ENV=production
-ENV DB_PATH=/app/data/fpv-tracker.db
+ENV DB_PATH=/app/data/flowchart.db
 
 CMD ["node", "--import", "tsx", "src/server.ts"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "fpv-tracker",
+  "name": "flowchart",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "fpv-tracker",
+      "name": "flowchart",
       "version": "1.0.0",
       "dependencies": {
         "@hono/node-server": "^1.19.9",

--- a/public/app.js
+++ b/public/app.js
@@ -3,6 +3,8 @@ let allTricks = [];
 let allDrills = [];
 let allResources = [];
 let allSchedule = [];
+let allPlans = [];
+let activePlan = null;
 let currentSessionId = null;
 let currentSessionData = null;
 
@@ -62,21 +64,23 @@ async function loadToday() {
   const stats = await api('/progress/stats');
   const gates = await api('/progress/gates');
 
-  // Determine current week (weeks since Feb 1 2026)
-  const programStart = new Date('2026-02-01');
+  const plan = activePlan || {};
+  const programStart = new Date(plan.start_date || '2026-02-01');
+  const totalWeeks = plan.total_weeks || 20;
+  const goalDate = new Date(plan.goal_date || '2026-07-01');
+  const goalDesc = plan.goal_description || 'Denver';
+
   const now = new Date();
-  const weekNum = Math.max(1, Math.min(20, Math.floor((now - programStart) / (7 * 86400000)) + 1));
+  const weekNum = Math.max(1, Math.min(totalWeeks, Math.floor((now - programStart) / (7 * 86400000)) + 1));
   const currentWeek = allSchedule.find(w => w.week_number === weekNum) || allSchedule[0];
   const phase = currentWeek ? currentWeek.phase : 1;
   const phaseNames = { 1: 'Indoor Acro', 2: 'Outdoor Transition', 3: 'Flow & Lines', 4: 'Denver Confidence' };
 
-  document.getElementById('today-week').textContent = `Week ${weekNum} of 20`;
+  document.getElementById('today-week').textContent = `Week ${weekNum} of ${totalWeeks}`;
   document.getElementById('today-phase').textContent = `Phase ${phase}: ${phaseNames[phase] || ''}`;
 
-  // Countdown to July 2026
-  const denver = new Date('2026-07-01');
-  const daysLeft = Math.max(0, Math.ceil((denver - now) / 86400000));
-  document.getElementById('today-countdown').innerHTML = `<strong>${daysLeft}</strong> days until Denver`;
+  const daysLeft = Math.max(0, Math.ceil((goalDate - now) / 86400000));
+  document.getElementById('today-countdown').innerHTML = `<strong>${daysLeft}</strong> days until ${esc(goalDesc)}`;
 
   // Streak
   document.getElementById('today-streak').innerHTML = `
@@ -129,6 +133,14 @@ function formatDate(d) {
   return `${parts[1]}/${parts[2]}`;
 }
 
+async function populatePlanSelect(selectedId) {
+  if (!allPlans.length) allPlans = await api('/plans');
+  const el = document.getElementById('sf-plan');
+  el.innerHTML = allPlans.map(p =>
+    `<option value="${p.id}"${p.id === selectedId ? ' selected' : ''}>${esc(p.name)}</option>`
+  ).join('');
+}
+
 // New session buttons
 document.getElementById('btn-new-session').addEventListener('click', () => newSession());
 document.getElementById('btn-new-session-2').addEventListener('click', () => newSession());
@@ -143,6 +155,7 @@ async function newSession() {
   document.getElementById('sf-location').value = 'home-room-A';
   document.getElementById('sf-platform').value = 'Air65';
   document.getElementById('sf-weather').value = 'indoor';
+  await populatePlanSelect(activePlan?.id);
   document.getElementById('sf-type').value = 'blocked-drill';
   document.getElementById('sf-notes').value = '';
   document.getElementById('pack-list').innerHTML = '';
@@ -171,6 +184,7 @@ async function newSession() {
       platform: document.getElementById('sf-platform').value,
       weather: document.getElementById('sf-weather').value,
       session_type: document.getElementById('sf-type').value,
+      training_plan_id: document.getElementById('sf-plan').value || null,
     }
   });
   currentSessionId = result.id;
@@ -192,6 +206,7 @@ async function openSession(id) {
   document.getElementById('sf-weather').value = data.weather;
   document.getElementById('sf-type').value = data.session_type;
   document.getElementById('sf-notes').value = data.notes || '';
+  await populatePlanSelect(data.training_plan_id);
 
   // Render packs
   renderPacks(data.packs);
@@ -253,7 +268,7 @@ function closeSessionForm() {
 
 // Auto-save header on blur
 function setupAutoSave() {
-  const fields = ['sf-date','sf-time-start','sf-time-end','sf-location','sf-platform','sf-weather','sf-type','sf-notes'];
+  const fields = ['sf-date','sf-time-start','sf-time-end','sf-location','sf-platform','sf-weather','sf-type','sf-plan','sf-notes'];
   fields.forEach(id => {
     const el = document.getElementById(id);
     el.onchange = () => saveSessionHeader();
@@ -274,6 +289,7 @@ async function saveSessionHeader() {
       weather: document.getElementById('sf-weather').value,
       session_type: document.getElementById('sf-type').value,
       notes: document.getElementById('sf-notes').value,
+      training_plan_id: document.getElementById('sf-plan').value || null,
     }
   });
 }
@@ -585,15 +601,21 @@ async function loadDenver() {
   const gates = await api('/progress/gates');
   const denverItems = await api('/denver');
 
-  // Countdown
+  const plan = activePlan || {};
   const now = new Date();
-  const denver = new Date('2026-07-01');
-  const daysLeft = Math.max(0, Math.ceil((denver - now) / 86400000));
-  document.getElementById('denver-countdown').innerHTML = `<strong>${daysLeft}</strong> days until Denver &middot; July 2026`;
+  const goalDate = new Date(plan.goal_date || '2026-07-01');
+  const goalDesc = plan.goal_description || 'Denver';
+  const programStart = new Date(plan.start_date || '2026-02-01');
+  const totalWeeks = plan.total_weeks || 20;
+
+  document.getElementById('goals-page-title').textContent = plan.name || 'Goals';
+
+  // Countdown
+  const daysLeft = Math.max(0, Math.ceil((goalDate - now) / 86400000));
+  document.getElementById('denver-countdown').innerHTML = `<strong>${daysLeft}</strong> days until ${esc(goalDesc)}`;
 
   // Timeline
-  const programStart = new Date('2026-02-01');
-  const currentWeek = Math.max(1, Math.min(20, Math.floor((now - programStart) / (7 * 86400000)) + 1));
+  const currentWeek = Math.max(1, Math.min(totalWeeks, Math.floor((now - programStart) / (7 * 86400000)) + 1));
   document.getElementById('week-timeline').innerHTML = '<div class="timeline">' +
     allSchedule.map(w => {
       const cls = [
@@ -693,4 +715,5 @@ if ('serviceWorker' in navigator) {
 api('/health').then(data => {
   if (data.version) document.getElementById('app-version').textContent = `v${data.version}`;
 }).catch(() => {});
-loadToday();
+
+api('/plans/active').then(p => { activePlan = p; }).catch(() => {}).finally(loadToday);

--- a/public/app.js
+++ b/public/app.js
@@ -65,9 +65,9 @@ async function loadToday() {
   const gates = await api('/progress/gates');
 
   const plan = activePlan || {};
-  const programStart = new Date(plan.start_date || '2026-02-01');
+  const programStart = new Date((plan.start_date || '2026-02-01') + 'T00:00:00');
   const totalWeeks = plan.total_weeks || 20;
-  const goalDate = new Date(plan.goal_date || '2026-07-01');
+  const goalDate = new Date((plan.goal_date || '2026-07-01') + 'T00:00:00');
   const goalDesc = plan.goal_description || 'Denver';
 
   const now = new Date();
@@ -136,8 +136,9 @@ function formatDate(d) {
 async function populatePlanSelect(selectedId) {
   if (!allPlans.length) allPlans = await api('/plans');
   const el = document.getElementById('sf-plan');
-  el.innerHTML = allPlans.map(p =>
-    `<option value="${p.id}"${p.id === selectedId ? ' selected' : ''}>${esc(p.name)}</option>`
+  const selId = selectedId != null ? String(selectedId) : '';
+  el.innerHTML = '<option value="">— no plan —</option>' + allPlans.map(p =>
+    `<option value="${p.id}"${String(p.id) === selId ? ' selected' : ''}>${esc(p.name)}</option>`
   ).join('');
 }
 
@@ -603,9 +604,9 @@ async function loadDenver() {
 
   const plan = activePlan || {};
   const now = new Date();
-  const goalDate = new Date(plan.goal_date || '2026-07-01');
+  const goalDate = new Date((plan.goal_date || '2026-07-01') + 'T00:00:00');
   const goalDesc = plan.goal_description || 'Denver';
-  const programStart = new Date(plan.start_date || '2026-02-01');
+  const programStart = new Date((plan.start_date || '2026-02-01') + 'T00:00:00');
   const totalWeeks = plan.total_weeks || 20;
 
   document.getElementById('goals-page-title').textContent = plan.name || 'Goals';

--- a/public/app.js
+++ b/public/app.js
@@ -716,4 +716,4 @@ api('/health').then(data => {
   if (data.version) document.getElementById('app-version').textContent = `v${data.version}`;
 }).catch(() => {});
 
-api('/plans/active').then(p => { activePlan = p; }).catch(() => {}).finally(loadToday);
+api('/plans/active').then(p => { if (p && !p.error) activePlan = p; }).catch(() => {}).finally(loadToday);

--- a/public/index.html
+++ b/public/index.html
@@ -68,7 +68,7 @@
 
     <!-- DENVER TAB -->
     <section id="page-denver" class="page">
-      <header class="page-header"><h1>Plan to Denver</h1></header>
+      <header class="page-header"><h1 id="goals-page-title">Goals</h1></header>
       <div id="denver-countdown" class="countdown"></div>
       <div id="week-timeline"></div>
       <h3>Phase Gates</h3>
@@ -150,6 +150,7 @@
             <option value="sim">Simulator</option>
           </select>
         </label>
+        <label>Plan <select id="sf-plan"></select></label>
         <label>Notes <textarea id="sf-notes" rows="2"></textarea></label>
       </div>
 
@@ -227,7 +228,7 @@
       <span class="nav-icon">&#9733;</span><span>Tricks</span>
     </button>
     <button class="nav-btn" data-page="page-denver">
-      <span class="nav-icon">&#9992;</span><span>Denver</span>
+      <span class="nav-icon">&#9992;</span><span>Goals</span>
     </button>
   </nav>
 

--- a/public/index.html
+++ b/public/index.html
@@ -66,7 +66,7 @@
       <div id="resources-list" class="subtab-content"></div>
     </section>
 
-    <!-- DENVER TAB -->
+    <!-- GOALS TAB -->
     <section id="page-denver" class="page">
       <header class="page-header"><h1 id="goals-page-title">Goals</h1></header>
       <div id="denver-countdown" class="countdown"></div>

--- a/src/api/plans.ts
+++ b/src/api/plans.ts
@@ -10,7 +10,7 @@ app.get('/', (c) => {
 
 app.get('/active', (c) => {
   const db = getDb();
-  const plan = db.prepare('SELECT * FROM training_plans WHERE active = 1 LIMIT 1').get();
+  const plan = db.prepare('SELECT * FROM training_plans WHERE active = 1 ORDER BY id DESC LIMIT 1').get();
   return plan ? c.json(plan) : c.json({ error: 'No active plan' }, 404);
 });
 

--- a/src/api/plans.ts
+++ b/src/api/plans.ts
@@ -1,0 +1,39 @@
+import { Hono } from 'hono';
+import { getDb } from '../db/index.js';
+
+const app = new Hono();
+
+app.get('/', (c) => {
+  const db = getDb();
+  return c.json(db.prepare('SELECT * FROM training_plans ORDER BY created_at').all());
+});
+
+app.get('/active', (c) => {
+  const db = getDb();
+  const plan = db.prepare('SELECT * FROM training_plans WHERE active = 1 LIMIT 1').get();
+  return plan ? c.json(plan) : c.json({ error: 'No active plan' }, 404);
+});
+
+app.post('/', async (c) => {
+  const db = getDb();
+  const body = await c.req.json();
+  const result = db.prepare(
+    'INSERT INTO training_plans (name, start_date, goal_date, goal_description, total_weeks, active, notes) VALUES (?, ?, ?, ?, ?, ?, ?)'
+  ).run(body.name, body.start_date, body.goal_date || null, body.goal_description || null, body.total_weeks || 20, body.active ? 1 : 0, body.notes || null);
+  return c.json({ id: result.lastInsertRowid }, 201);
+});
+
+app.put('/:id', async (c) => {
+  const db = getDb();
+  const id = c.req.param('id');
+  const body = await c.req.json();
+  if (body.active) {
+    db.prepare('UPDATE training_plans SET active = 0').run();
+  }
+  db.prepare(
+    'UPDATE training_plans SET name=?, start_date=?, goal_date=?, goal_description=?, total_weeks=?, active=?, notes=? WHERE id=?'
+  ).run(body.name, body.start_date, body.goal_date || null, body.goal_description || null, body.total_weeks || 20, body.active ? 1 : 0, body.notes || null, id);
+  return c.json({ ok: true });
+});
+
+export default app;

--- a/src/api/plans.ts
+++ b/src/api/plans.ts
@@ -17,9 +17,13 @@ app.get('/active', (c) => {
 app.post('/', async (c) => {
   const db = getDb();
   const body = await c.req.json();
+  const isActive = body.active === true || body.active === 1 ? 1 : 0;
+  if (isActive) {
+    db.prepare('UPDATE training_plans SET active = 0').run();
+  }
   const result = db.prepare(
     'INSERT INTO training_plans (name, start_date, goal_date, goal_description, total_weeks, active, notes) VALUES (?, ?, ?, ?, ?, ?, ?)'
-  ).run(body.name, body.start_date, body.goal_date || null, body.goal_description || null, body.total_weeks || 20, body.active ? 1 : 0, body.notes || null);
+  ).run(body.name, body.start_date, body.goal_date || null, body.goal_description || null, body.total_weeks || 20, isActive, body.notes || null);
   return c.json({ id: result.lastInsertRowid }, 201);
 });
 
@@ -27,12 +31,13 @@ app.put('/:id', async (c) => {
   const db = getDb();
   const id = c.req.param('id');
   const body = await c.req.json();
-  if (body.active) {
+  const isActive = body.active === true || body.active === 1 ? 1 : 0;
+  if (isActive) {
     db.prepare('UPDATE training_plans SET active = 0').run();
   }
   db.prepare(
     'UPDATE training_plans SET name=?, start_date=?, goal_date=?, goal_description=?, total_weeks=?, active=?, notes=? WHERE id=?'
-  ).run(body.name, body.start_date, body.goal_date || null, body.goal_description || null, body.total_weeks || 20, body.active ? 1 : 0, body.notes || null, id);
+  ).run(body.name, body.start_date, body.goal_date || null, body.goal_description || null, body.total_weeks || 20, isActive, body.notes || null, id);
   return c.json({ ok: true });
 });
 

--- a/src/api/plans.ts
+++ b/src/api/plans.ts
@@ -18,12 +18,13 @@ app.post('/', async (c) => {
   const db = getDb();
   const body = await c.req.json();
   const isActive = body.active === true || body.active === 1 ? 1 : 0;
-  if (isActive) {
-    db.prepare('UPDATE training_plans SET active = 0').run();
-  }
-  const result = db.prepare(
-    'INSERT INTO training_plans (name, start_date, goal_date, goal_description, total_weeks, active, notes) VALUES (?, ?, ?, ?, ?, ?, ?)'
-  ).run(body.name, body.start_date, body.goal_date || null, body.goal_description || null, body.total_weeks || 20, isActive, body.notes || null);
+  const totalWeeks = parseInt(body.total_weeks) || 20;
+  const result = db.transaction(() => {
+    if (isActive) db.prepare('UPDATE training_plans SET active = 0').run();
+    return db.prepare(
+      'INSERT INTO training_plans (name, start_date, goal_date, goal_description, total_weeks, active, notes) VALUES (?, ?, ?, ?, ?, ?, ?)'
+    ).run(body.name, body.start_date, body.goal_date || null, body.goal_description || null, totalWeeks, isActive, body.notes || null);
+  })();
   return c.json({ id: result.lastInsertRowid }, 201);
 });
 
@@ -32,12 +33,13 @@ app.put('/:id', async (c) => {
   const id = c.req.param('id');
   const body = await c.req.json();
   const isActive = body.active === true || body.active === 1 ? 1 : 0;
-  if (isActive) {
-    db.prepare('UPDATE training_plans SET active = 0').run();
-  }
-  db.prepare(
-    'UPDATE training_plans SET name=?, start_date=?, goal_date=?, goal_description=?, total_weeks=?, active=?, notes=? WHERE id=?'
-  ).run(body.name, body.start_date, body.goal_date || null, body.goal_description || null, body.total_weeks || 20, isActive, body.notes || null, id);
+  const totalWeeks = parseInt(body.total_weeks) || 20;
+  db.transaction(() => {
+    if (isActive) db.prepare('UPDATE training_plans SET active = 0').run();
+    db.prepare(
+      'UPDATE training_plans SET name=?, start_date=?, goal_date=?, goal_description=?, total_weeks=?, active=?, notes=? WHERE id=?'
+    ).run(body.name, body.start_date, body.goal_date || null, body.goal_description || null, totalWeeks, isActive, body.notes || null, id);
+  })();
   return c.json({ ok: true });
 });
 

--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -43,8 +43,8 @@ app.post('/', async (c) => {
   const db = getDb();
   const body = await c.req.json();
   const stmt = db.prepare(`
-    INSERT INTO sessions (date, time_start, time_end, location, platform, weather, session_type, notes)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO sessions (date, time_start, time_end, location, platform, weather, session_type, notes, training_plan_id)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
   const result = stmt.run(
     body.date || new Date().toISOString().split('T')[0],
@@ -54,7 +54,8 @@ app.post('/', async (c) => {
     body.platform || 'Air65',
     body.weather || 'indoor',
     body.session_type || 'blocked-drill',
-    body.notes || ''
+    body.notes || '',
+    body.training_plan_id || null
   );
   return c.json({ id: result.lastInsertRowid }, 201);
 });
@@ -65,9 +66,9 @@ app.put('/:id', async (c) => {
   const id = c.req.param('id');
   const body = await c.req.json();
   db.prepare(`
-    UPDATE sessions SET date=?, time_start=?, time_end=?, location=?, platform=?, weather=?, session_type=?, notes=?
+    UPDATE sessions SET date=?, time_start=?, time_end=?, location=?, platform=?, weather=?, session_type=?, notes=?, training_plan_id=?
     WHERE id=?
-  `).run(body.date, body.time_start, body.time_end, body.location, body.platform, body.weather, body.session_type, body.notes, id);
+  `).run(body.date, body.time_start, body.time_end, body.location, body.platform, body.weather, body.session_type, body.notes, body.training_plan_id || null, id);
   return c.json({ ok: true });
 });
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const DB_PATH = process.env.DB_PATH || join(__dirname, '..', '..', 'data', 'fpv-tracker.db');
+const DB_PATH = process.env.DB_PATH || join(__dirname, '..', '..', 'data', 'flowchart.db');
 
 let db: Database.Database;
 
@@ -23,10 +23,22 @@ function initDb(db: Database.Database) {
   const schema = readFileSync(join(__dirname, 'schema.sql'), 'utf-8');
   db.exec(schema);
 
-  // Only seed if tricks table is empty
+  const sessionCols = (db.pragma('table_info(sessions)') as { name: string }[]).map(c => c.name);
+  if (!sessionCols.includes('training_plan_id')) {
+    db.exec('ALTER TABLE sessions ADD COLUMN training_plan_id INTEGER REFERENCES training_plans(id)');
+  }
+
   const count = db.prepare('SELECT COUNT(*) as c FROM tricks').get() as { c: number };
   if (count.c === 0) {
     const seed = readFileSync(join(__dirname, 'seed.sql'), 'utf-8');
     db.exec(seed);
+  }
+
+  const planCount = db.prepare('SELECT COUNT(*) as c FROM training_plans').get() as { c: number };
+  if (planCount.c === 0) {
+    db.prepare(
+      'INSERT INTO training_plans (name, start_date, goal_date, goal_description, total_weeks, active) VALUES (?, ?, ?, ?, ?, 1)'
+    ).run('Plan to Denver', '2026-02-01', '2026-07-01', 'Denver', 20);
+    db.prepare('UPDATE sessions SET training_plan_id = 1 WHERE training_plan_id IS NULL').run();
   }
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -36,9 +36,9 @@ function initDb(db: Database.Database) {
 
   const planCount = db.prepare('SELECT COUNT(*) as c FROM training_plans').get() as { c: number };
   if (planCount.c === 0) {
-    db.prepare(
+    const planResult = db.prepare(
       'INSERT INTO training_plans (name, start_date, goal_date, goal_description, total_weeks, active) VALUES (?, ?, ?, ?, ?, 1)'
     ).run('Plan to Denver', '2026-02-01', '2026-07-01', 'Denver', 20);
-    db.prepare('UPDATE sessions SET training_plan_id = 1 WHERE training_plan_id IS NULL').run();
+    db.prepare('UPDATE sessions SET training_plan_id = ? WHERE training_plan_id IS NULL').run(planResult.lastInsertRowid);
   }
 }

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -171,3 +171,15 @@ CREATE TABLE IF NOT EXISTS week_schedule (
   sim_focus TEXT DEFAULT '',
   go_nogo TEXT DEFAULT ''
 );
+
+CREATE TABLE IF NOT EXISTS training_plans (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  start_date TEXT NOT NULL,
+  goal_date TEXT,
+  goal_description TEXT,
+  total_weeks INTEGER NOT NULL DEFAULT 20,
+  active INTEGER NOT NULL DEFAULT 0,
+  notes TEXT,
+  created_at TEXT DEFAULT (datetime('now'))
+);

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ import tricks from './api/tricks.js';
 import equipment from './api/equipment.js';
 import denver from './api/denver.js';
 import exportimport from './api/exportimport.js';
+import plans from './api/plans.js';
 
 const { version: APP_VERSION } = JSON.parse(
   readFileSync(new URL('../package.json', import.meta.url), 'utf-8')
@@ -22,6 +23,7 @@ app.route('/api/tricks', tricks);
 app.route('/api/equipment', equipment);
 app.route('/api/denver', denver);
 app.route('/api/data', exportimport);
+app.route('/api/plans', plans);
 
 // Health check
 app.get('/api/health', (c) => c.json({ status: 'ok', version: APP_VERSION }));


### PR DESCRIPTION
## Summary

- Adds `training_plans` table with `name`, `start_date`, `goal_date`, `goal_description`, `total_weeks`, and `active` flag
- Schema migration in `initDb` adds `training_plan_id` FK to `sessions`; seeds the default "Plan to Denver" plan on first run and backfills existing sessions
- New `/api/plans` endpoints: `GET /`, `GET /active`, `POST /`, `PUT /:id`
- Today and Goals tabs read all dates/durations from the active plan instead of hardcoded strings
- Goals tab (formerly "Denver") page title updates dynamically from `plan.name`
- Session form Info tab gains an optional Plan selector defaulting to the active plan; persisted on create and update

## Test plan

- [ ] `GET /api/plans/active` returns the seeded "Plan to Denver" plan
- [ ] Today tab countdown and "Week X of 20" use plan dates
- [ ] Goals tab title shows plan name; countdown uses `goal_description`
- [ ] Nav tab shows "Goals" instead of "Denver"
- [ ] Session form shows Plan selector defaulting to active plan
- [ ] New session saved with `training_plan_id`; existing session PUT preserves it

Resolves #24

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4SScoqQnH3HaehhJxLDqB)_